### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/btotharye/mattermost_wrapper.png?label=ready&title=Ready)](https://waffle.io/btotharye/mattermost_wrapper?utm_source=badge)
 # Python Mattermost v4 API Wrapper
 This will be a api v4 wrapper for mattermost.  The plan is to use this for bots, etc.
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/btotharye/mattermost_wrapper

This was requested by a real person (user btotharye) on waffle.io, we're not trying to spam you.